### PR TITLE
Run build in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,3 +26,5 @@ jobs:
       - run: yarn run prettier
 
       - run: yarn run lint
+
+      - run: yarn run build


### PR DESCRIPTION
We were only doing prettier/lint in CI. Add build so that we catch errors in CI and not in the netlify build.