### PR TITLE
Update Designs for Landing/Results page Buttons

### DIFF
--- a/src/components/LandingPage/LandingPage.styled.tsx
+++ b/src/components/LandingPage/LandingPage.styled.tsx
@@ -63,31 +63,4 @@ export const StyledPrimaryButton = styled.button`
   transition-duration: 150ms;
 `
 
-export const StyledManualAddress = styled.div`
-  margin: 10px 0 60px 0;
-  cursor: pointer;
-  font-size: 14px;
-  color: #836303;
-  font-weight: bold;
-`
-
-export const StyledAddressForm = styled.form`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-
-  input {
-    display: flex;
-    width: 100%;
-    background: #e9e9e9;
-    padding: 15px;
-    font-size: 16px;
-    border-radius: 15px;
-    border: 0;
-    margin: 20px 0;
-  }
-`
-
 export default StyledLandingPage

--- a/src/components/LandingPage/LandingPage.styled.tsx
+++ b/src/components/LandingPage/LandingPage.styled.tsx
@@ -27,40 +27,14 @@ export const StyledMainTextBox = styled.div`
     margin-top: 30px;
   }
 `
-
-export const StyledPrimaryButton = styled.button`
-  cursor: pointer;
-  border: none;
-  border-radius: 69px;
-  background-color: rgb(var(--color-primary));
-  width: 317px;
-  height: 54px;
-  //styleName: Heading 6;
-  font-family: Poppins;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 22px;
-  letter-spacing: 0em;
-  text-align: center;
-  margin-bottom: 20px;
+export const StyledButtonsContainer = styled.div`
+  display: flex;
   align-items: center;
-  justify-content: center;
-
-  &:hover {
-    filter: brightness(0.9);
+  justify-content: space-around;
+  width: 872px;
+  @media only screen and (max-width: 864px) {
+    flex-direction: column;
   }
-
-  &:focus {
-    box-shadow: 0 0 6px 0 rgba(var(--color-primary));
-    transition: box-shadow 50ms;
-  }
-
-  &:active {
-    filter: brightness(0.8);
-  }
-
-  transition-duration: 150ms;
 `
 
 export default StyledLandingPage

--- a/src/components/LandingPage/LandingPage.styled.tsx
+++ b/src/components/LandingPage/LandingPage.styled.tsx
@@ -34,6 +34,7 @@ export const StyledButtonsContainer = styled.div`
   width: 872px;
   @media only screen and (max-width: 864px) {
     flex-direction: column;
+    height: 200px;
   }
 `
 

--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react'
-import StyledLandingPage, { StyledMainTextBox, StyledPrimaryButton } from './LandingPage.styled'
+import StyledLandingPage, { StyledMainTextBox, StyledButtonsContainer } from './LandingPage.styled'
 import EthAddressForm from '../common/EthAddressForm'
-import Modal from '../../components/Modal'
+import PrimaryButton from '../common/PrimaryButton'
 import LogoSvg from '../../assets/logo.svg'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
-import { CircleChevronRightFill } from 'akar-icons'
 
 interface LandingPageProps {
   onConnect: Function
@@ -71,18 +70,22 @@ const LandingPage = ({ onConnect, walletAddress }: LandingPageProps) => {
         <p>Did you know, you might have some unsuspected transactions, which might be draining away your wallet?</p>
         <p>We help you scan and find those sandwiches in your transactions.</p>
       </StyledMainTextBox>
-      <StyledPrimaryButton
-        onClick={async () => {
-          const { address, connected } = await onConnect()
-          if (connected) {
-            history.push(`/${address}`)
-          }
-        }}
-      >
-        Connect Wallet
-      </StyledPrimaryButton>
-      {/*EthAddressForm*/}
-      <EthAddressForm />
+
+      <StyledButtonsContainer>
+        <PrimaryButton
+          onClick={async () => {
+            const { address, connected } = await onConnect()
+            if (connected) {
+              history.push(`/${address}`)
+            }
+          }}
+        >
+          Connect Wallet
+        </PrimaryButton>
+        <div>OR</div>
+        {/*EthAddressForm*/}
+        <EthAddressForm />
+      </StyledButtonsContainer>
     </StyledLandingPage>
   )
 }

--- a/src/components/LandingPage/index.tsx
+++ b/src/components/LandingPage/index.tsx
@@ -1,14 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import StyledLandingPage, {
-  StyledMainTextBox,
-  StyledPrimaryButton,
-  StyledManualAddress,
-  StyledAddressForm,
-} from './LandingPage.styled'
+import StyledLandingPage, { StyledMainTextBox, StyledPrimaryButton } from './LandingPage.styled'
+import EthAddressForm from '../common/EthAddressForm'
 import Modal from '../../components/Modal'
 import LogoSvg from '../../assets/logo.svg'
 import { useHistory, useLocation, useParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
+import { CircleChevronRightFill } from 'akar-icons'
 
 interface LandingPageProps {
   onConnect: Function
@@ -53,12 +50,6 @@ const LandingPage = ({ onConnect, walletAddress }: LandingPageProps) => {
     setMetaDesc(constructMetaDescription(location.search))
   }, [location.search])
 
-  const manualAddressSubmit = () => {
-    if (inputVal) {
-      history.push(`/${inputVal}`)
-    }
-  }
-
   return (
     <StyledLandingPage>
       {metaDesc ? (
@@ -90,19 +81,8 @@ const LandingPage = ({ onConnect, walletAddress }: LandingPageProps) => {
       >
         Connect Wallet
       </StyledPrimaryButton>
-      <StyledManualAddress onClick={() => setModalOpen(true)}>Manually enter a wallet address</StyledManualAddress>
-      <Modal open={isModalOpen} setModalOpen={setModalOpen} title="Enter a wallet address to continue">
-        <StyledAddressForm onSubmit={() => manualAddressSubmit()}>
-          <input
-            type="text"
-            value={inputVal}
-            onChange={(e: any) => setInputVal(e.target.value)}
-            required
-            placeholder="Enter Wallet or ENS Address"
-          />
-          <StyledPrimaryButton type="submit">Submit</StyledPrimaryButton>
-        </StyledAddressForm>
-      </Modal>
+      {/*EthAddressForm*/}
+      <EthAddressForm />
     </StyledLandingPage>
   )
 }

--- a/src/components/SandwichPage/LoadingSandwiches.tsx
+++ b/src/components/SandwichPage/LoadingSandwiches.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
-import styled from 'styled-components'
-import hamburgers from '../../assets/hamburgers.svg'
 import hamburgerLine from '../../assets/hamburger-line.svg'
 import logoStripped from '../../assets/logo-stripped.svg'
-import errorHamburger from '../../assets/error-hamburger.svg'
-import { StyledPrimaryButton } from '../LandingPage/LandingPage.styled'
+import PrimaryButton from '../common/PrimaryButton'
 import { StyledLoadingSandwichesDisplay, StyledMainTextBox } from './LoadingSandwiches.styled'
 import { useHistory } from 'react-router-dom'
 
@@ -50,7 +47,7 @@ const LoadingSandwichesDisplay = ({
         <h1>{header}</h1>
         <p>{paragraph1}</p>
         {error && (
-          <StyledPrimaryButton
+          <PrimaryButton
             onClick={() => {
               /** If wallet address is bad reset app and send to home page **/
               if (error.toLowerCase().search('bad wallet address') !== -1) {
@@ -62,7 +59,7 @@ const LoadingSandwichesDisplay = ({
             }}
           >
             Retry
-          </StyledPrimaryButton>
+          </PrimaryButton>
         )}
       </StyledMainTextBox>
     </StyledLoadingSandwichesDisplay>

--- a/src/components/SandwichPage/ResultsView.styled.tsx
+++ b/src/components/SandwichPage/ResultsView.styled.tsx
@@ -150,6 +150,18 @@ export const StyledDetailedTableContainer = styled.div`
   }
 `
 
+export const ButtonsGroup = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1.5rem;
+  width: 812px;
+  max-width: 1024px;
+  @media only screen and (max-width: 864px) {
+    flex-direction: column;
+    height: 160px;
+  }
+`
 export const StyledAttributesItem = styled.span`
   width: 50px;
   height: 30px;
@@ -169,8 +181,8 @@ export const StyledCTAButton = styled.a`
   box-shadow: 0px 10px 16px rgba(199, 150, 3, 0.24);
   border-radius: 16px;
   background-color: rgb(var(--color-primary));
-  width: 342px;
-  height: 54px;
+  width: 362px;
+  height: 60px;
   //styleName: Heading 6;
   color: #836303;
   font-family: Poppins;
@@ -181,7 +193,6 @@ export const StyledCTAButton = styled.a`
   letter-spacing: 0em;
   text-align: center;
   text-decoration: none;
-  margin-top: 1.5rem;
   &:hover {
     filter: brightness(0.9);
   }

--- a/src/components/SandwichPage/ResultsView.styled.tsx
+++ b/src/components/SandwichPage/ResultsView.styled.tsx
@@ -159,7 +159,7 @@ export const ButtonsGroup = styled.div`
   max-width: 1024px;
   @media only screen and (max-width: 864px) {
     flex-direction: column;
-    height: 160px;
+    height: 150px;
   }
 `
 export const StyledAttributesItem = styled.span`

--- a/src/components/SandwichPage/ResultsView.styled.tsx
+++ b/src/components/SandwichPage/ResultsView.styled.tsx
@@ -178,18 +178,18 @@ export const StyledAttributesItem = styled.span`
 
 export const StyledCTAButton = styled.a`
   cursor: pointer;
-  box-shadow: 0px 10px 16px rgba(199, 150, 3, 0.24);
+  box-shadow: 0px 10px 16px #cae6fa;
   border-radius: 16px;
-  background-color: rgb(var(--color-primary));
+  background-color: #41afff;
   width: 362px;
   height: 60px;
   //styleName: Heading 6;
-  color: #836303;
+  color: #fff;
   font-family: Poppins;
   font-size: 20px;
   font-style: normal;
-  font-weight: 700;
-  line-height: 54px;
+  font-weight: 600;
+  line-height: 58px;
   letter-spacing: 0em;
   text-align: center;
   text-decoration: none;

--- a/src/components/SandwichPage/ResultsView.tsx
+++ b/src/components/SandwichPage/ResultsView.tsx
@@ -155,7 +155,7 @@ const ResultsView = ({ data = [], fetchingComplete }: DetailedTableProps) => {
           <TwitterFill style={{ display: 'inline', verticalAlign: 'middle', marginRight: '1rem' }} size={24} />
           Share your sandwiches
         </StyledCTAButton>
-        <EthAddressForm className="small" inputPlaceholder={'Enter New Wallet Address or ENS to Scan'} />
+        <EthAddressForm className="small" inputPlaceholder={'Enter new wallet address or ENS'} />
       </ButtonsGroup>
       <StyledDetailedTableContainer>
         <MaterialTable

--- a/src/components/SandwichPage/ResultsView.tsx
+++ b/src/components/SandwichPage/ResultsView.tsx
@@ -11,7 +11,9 @@ import {
   StyledDetailedTableContainer,
   StyledAttributesItem,
   StyledCTAButton,
+  ButtonsGroup,
 } from './ResultsView.styled'
+import EthAddressForm from '../common/EthAddressForm'
 import SummaryCard from './SummaryCard'
 import MaterialTable from 'material-table'
 import statusIcon from '../../assets/status-icon.svg'
@@ -145,13 +147,16 @@ const ResultsView = ({ data = [], fetchingComplete }: DetailedTableProps) => {
           error={totalEthProfitError}
         />
       </StyledSummarySandwichTableWrapper>
-      <StyledCTAButton
-        href={twitterShareLink(totalSandwiches, totalEthProfit || 0, juiciestEthSandwich.profit)}
-        target="_blank"
-      >
-        <TwitterFill style={{ display: 'inline', verticalAlign: 'middle', marginRight: '1rem' }} size={24} />
-        Share your sandwiches
-      </StyledCTAButton>
+      <ButtonsGroup>
+        <StyledCTAButton
+          href={twitterShareLink(totalSandwiches, totalEthProfit || 0, juiciestEthSandwich.profit)}
+          target="_blank"
+        >
+          <TwitterFill style={{ display: 'inline', verticalAlign: 'middle', marginRight: '1rem' }} size={24} />
+          Share your sandwiches
+        </StyledCTAButton>
+        <EthAddressForm className="small" />
+      </ButtonsGroup>
       <StyledDetailedTableContainer>
         <MaterialTable
           style={{

--- a/src/components/SandwichPage/ResultsView.tsx
+++ b/src/components/SandwichPage/ResultsView.tsx
@@ -155,7 +155,7 @@ const ResultsView = ({ data = [], fetchingComplete }: DetailedTableProps) => {
           <TwitterFill style={{ display: 'inline', verticalAlign: 'middle', marginRight: '1rem' }} size={24} />
           Share your sandwiches
         </StyledCTAButton>
-        <EthAddressForm className="small" />
+        <EthAddressForm className="small" inputPlaceholder={'Enter New Wallet Address or ENS to Scan'} />
       </ButtonsGroup>
       <StyledDetailedTableContainer>
         <MaterialTable

--- a/src/components/SandwichPage/SummaryCard.styled.tsx
+++ b/src/components/SandwichPage/SummaryCard.styled.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 const StyledSummaryCard = styled.div`
   padding: 18px;
-  width: 195px;
+  width: 199px;
   height: auto;
   background-color: #ffbf00;
   background: #fcfcfc;

--- a/src/components/common/EthAddressForm/EthAddressForm.styled.ts
+++ b/src/components/common/EthAddressForm/EthAddressForm.styled.ts
@@ -5,6 +5,11 @@ export const StyledAddressForm = styled.form`
   border-radius: 16px;
   background: #e9e9e9;
   display: flex;
+
+  &.small {
+    height: 60px;
+    width: 394px;
+  }
   .input-wrapper {
     flex: 1;
     margin-left: 20px;

--- a/src/components/common/EthAddressForm/EthAddressForm.styled.ts
+++ b/src/components/common/EthAddressForm/EthAddressForm.styled.ts
@@ -19,7 +19,7 @@ export const StyledAddressForm = styled.form`
     background-color: #c4c4c4;
   }
   input {
-    height: 72px;
+    height: 100%;
     width: 100%;
     border: 0;
     display: inline;
@@ -45,5 +45,13 @@ export const StyledAddressForm = styled.form`
     float: right;
     border-top-right-radius: 16px;
     border-bottom-right-radius: 16px;
+  }
+  &.small {
+    .input-wrapper {
+      height: 60px;
+    }
+    button {
+      height: 60px;
+    }
   }
 `

--- a/src/components/common/EthAddressForm/EthAddressForm.styled.ts
+++ b/src/components/common/EthAddressForm/EthAddressForm.styled.ts
@@ -1,0 +1,50 @@
+import styled from 'styled-components'
+import { StyledPrimaryButton } from '../../LandingPage/LandingPage.styled'
+
+export const StyledAddressForm = styled.form`
+  width: 368px;
+  border-radius: 16px;
+  background: #e9e9e9;
+  display: flex;
+  .input-wrapper {
+    flex: 1;
+    margin-left: 20px;
+    height: 72px;
+    display: inline;
+    background: #e9e9e9;
+  }
+  .rectangle {
+    display: inline;
+    padding: 1.5px;
+    min-height: 24px;
+    background-color: #c4c4c4;
+  }
+  input {
+    height: 72px;
+    width: 100%;
+    border: 0;
+    display: inline;
+    background: #e9e9e9;
+    padding: 15px;
+    font-size: 18px;
+    color: #434343;
+
+    :focus,
+    textarea:focus,
+    select:focus {
+      outline: none;
+    }
+  }
+  button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 72px;
+    height: 72px;
+    background-color: rgba(var(--color-primary));
+    border: none;
+    float: right;
+    border-top-right-radius: 16px;
+    border-bottom-right-radius: 16px;
+  }
+`

--- a/src/components/common/EthAddressForm/EthAddressForm.styled.ts
+++ b/src/components/common/EthAddressForm/EthAddressForm.styled.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { StyledPrimaryButton } from '../../LandingPage/LandingPage.styled'
 
 export const StyledAddressForm = styled.form`
   width: 368px;

--- a/src/components/common/EthAddressForm/EthAddressForm.tsx
+++ b/src/components/common/EthAddressForm/EthAddressForm.tsx
@@ -2,7 +2,7 @@ import { CircleChevronRightFill } from 'akar-icons'
 import { StyledAddressForm } from './EthAddressForm.styled'
 import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
-import { StyledPrimaryButton } from '../../LandingPage/LandingPage.styled'
+import PrimaryButton from '../PrimaryButton'
 
 const EthAddressForm = () => {
   const [inputVal, setInputVal] = useState()
@@ -26,12 +26,12 @@ const EthAddressForm = () => {
           placeholder="Enter Wallet Address"
         />
       </div>
-      <StyledPrimaryButton
+      <PrimaryButton
         //Style Overrides
         style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0, padding: 0, margin: 0 }}
       >
         <CircleChevronRightFill size={26} style={{ color: '#836303' }} />
-      </StyledPrimaryButton>
+      </PrimaryButton>
     </StyledAddressForm>
   )
 }

--- a/src/components/common/EthAddressForm/EthAddressForm.tsx
+++ b/src/components/common/EthAddressForm/EthAddressForm.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import PrimaryButton from '../PrimaryButton'
 
-const EthAddressForm = () => {
+const EthAddressForm = ({ ...props }) => {
   const [inputVal, setInputVal] = useState()
   let history = useHistory()
 
@@ -15,7 +15,7 @@ const EthAddressForm = () => {
   }
 
   return (
-    <StyledAddressForm onSubmit={() => manualAddressSubmit()}>
+    <StyledAddressForm onSubmit={() => manualAddressSubmit()} {...props}>
       <div className={'input-wrapper'}>
         <div className="rectangle" />
         <input

--- a/src/components/common/EthAddressForm/EthAddressForm.tsx
+++ b/src/components/common/EthAddressForm/EthAddressForm.tsx
@@ -9,7 +9,7 @@ type EthAddressFormProps = {
   className?: string
 }
 
-const EthAddressForm = ({ inputPlaceholder = 'Enter Wallet Address or ENS', ...props }: EthAddressFormProps) => {
+const EthAddressForm = ({ inputPlaceholder = 'Enter wallet address or ENS', ...props }: EthAddressFormProps) => {
   const [inputVal, setInputVal] = useState()
   let history = useHistory()
 

--- a/src/components/common/EthAddressForm/EthAddressForm.tsx
+++ b/src/components/common/EthAddressForm/EthAddressForm.tsx
@@ -1,0 +1,39 @@
+import { CircleChevronRightFill } from 'akar-icons'
+import { StyledAddressForm } from './EthAddressForm.styled'
+import React, { useState } from 'react'
+import { useHistory } from 'react-router-dom'
+import { StyledPrimaryButton } from '../../LandingPage/LandingPage.styled'
+
+const EthAddressForm = () => {
+  const [inputVal, setInputVal] = useState()
+  let history = useHistory()
+
+  let manualAddressSubmit = () => {
+    if (inputVal) {
+      history.push(`/${inputVal}`)
+    }
+  }
+
+  return (
+    <StyledAddressForm onSubmit={() => manualAddressSubmit()}>
+      <div className={'input-wrapper'}>
+        <div className="rectangle" />
+        <input
+          type="text"
+          value={inputVal}
+          onChange={(e: any) => setInputVal(e.target.value)}
+          required
+          placeholder="Enter Wallet Address"
+        />
+      </div>
+      <StyledPrimaryButton
+        //Style Overrides
+        style={{ borderTopLeftRadius: 0, borderBottomLeftRadius: 0, padding: 0, margin: 0 }}
+      >
+        <CircleChevronRightFill size={26} style={{ color: '#836303' }} />
+      </StyledPrimaryButton>
+    </StyledAddressForm>
+  )
+}
+
+export default EthAddressForm

--- a/src/components/common/EthAddressForm/EthAddressForm.tsx
+++ b/src/components/common/EthAddressForm/EthAddressForm.tsx
@@ -4,7 +4,12 @@ import React, { useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import PrimaryButton from '../PrimaryButton'
 
-const EthAddressForm = ({ ...props }) => {
+type EthAddressFormProps = {
+  inputPlaceholder?: string
+  className?: string
+}
+
+const EthAddressForm = ({ inputPlaceholder = 'Enter Wallet Address or ENS', ...props }: EthAddressFormProps) => {
   const [inputVal, setInputVal] = useState()
   let history = useHistory()
 
@@ -23,7 +28,7 @@ const EthAddressForm = ({ ...props }) => {
           value={inputVal}
           onChange={(e: any) => setInputVal(e.target.value)}
           required
-          placeholder="Enter Wallet Address"
+          placeholder={inputPlaceholder}
         />
       </div>
       <PrimaryButton

--- a/src/components/common/EthAddressForm/index.ts
+++ b/src/components/common/EthAddressForm/index.ts
@@ -1,0 +1,2 @@
+import EthAddressForm from './EthAddressForm'
+export default EthAddressForm

--- a/src/components/common/PrimaryButton/PrimaryButton.styled.ts
+++ b/src/components/common/PrimaryButton/PrimaryButton.styled.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components'
+
+export default styled.button`
+  cursor: pointer;
+  border: none;
+  border-radius: 69px;
+  color: #836303;
+  background-color: rgb(var(--color-primary));
+  width: 368px;
+  border-radius: 16px;
+  height: 72px;
+  //styleName: Heading 6;
+  font-family: Poppins;
+  font-weight: 600;
+  font-size: 24px;
+  line-height: 28px;
+  letter-spacing: 0em;
+  text-align: center;
+  margin-bottom: 20px;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    filter: brightness(0.9);
+  }
+
+  &:focus {
+    box-shadow: 0 0 6px 0 rgba(var(--color-primary));
+    transition: box-shadow 50ms;
+  }
+
+  &:active {
+    filter: brightness(0.8);
+  }
+
+  transition-duration: 150ms;
+`

--- a/src/components/common/PrimaryButton/PrimaryButton.styled.ts
+++ b/src/components/common/PrimaryButton/PrimaryButton.styled.ts
@@ -16,7 +16,6 @@ export default styled.button`
   line-height: 28px;
   letter-spacing: 0em;
   text-align: center;
-  margin-bottom: 20px;
   align-items: center;
   justify-content: center;
 

--- a/src/components/common/PrimaryButton/index.ts
+++ b/src/components/common/PrimaryButton/index.ts
@@ -1,0 +1,2 @@
+import PrimaryButton from './PrimaryButton.styled'
+export default PrimaryButton


### PR DESCRIPTION
## Changes

- Adds a new EthAddressForm component form (removing the modal for the previous address button)
- Restyles landing page and adds the EthAddressForm component to it
- Restyles the results page buttons and adds the EthAddressForm component to it
- Adds mobile break points and styling for the button groups above pages
- adds new Twitter button design

## Screenshots
Mobile Style:
![image](https://user-images.githubusercontent.com/7134689/122663594-9f971680-d150-11eb-980e-a29e3e1adb83.png)

## Checklist

- [ ] Lots of Sandwiches: http://localhost:3001/0xb1adceddb2941033a090dd166a462fe1c2029484
- [ ] No Sandwiches: http://localhost:3001/0xd3230876c670971797a1f55a7bc100bec25759f1
- [ ] Connect/Disconnect from header wallet button
- [ ] Click Logo in header bar to go back to home page

Fixes #83
