### PR TITLE
Hotfix/styling fixes for firefox and safari

### DIFF
--- a/src/components/SandwichPage/ResultsView.styled.tsx
+++ b/src/components/SandwichPage/ResultsView.styled.tsx
@@ -106,9 +106,18 @@ export const StyledPageHeader = styled.div`
     font-size: 20px;
     font-style: normal;
     font-weight: 400;
-    line-height: 39px;
+    line-height: 38px;
     letter-spacing: 0em;
     text-align: center;
+  }
+  .mistx-link {
+    border: 3px solid rgb(var(--color-primary));
+    box-sizing: border-box;
+    border-radius: 10px;
+    padding: 2px 16px;
+    color: #836303;
+    font-weight: bold;
+    text-decoration: none;
   }
 `
 

--- a/src/components/SandwichPage/ResultsView.styled.tsx
+++ b/src/components/SandwichPage/ResultsView.styled.tsx
@@ -193,6 +193,9 @@ export const StyledCTAButton = styled.a`
   letter-spacing: 0em;
   text-align: center;
   text-decoration: none;
+  @media only screen and (max-width: 864px) {
+    width: 395px;
+  }
   &:hover {
     filter: brightness(0.9);
   }

--- a/src/components/SandwichPage/ResultsView.tsx
+++ b/src/components/SandwichPage/ResultsView.tsx
@@ -42,7 +42,7 @@ const PageHeader = (x: number) => {
     body = (
       <>
         Well played - use{' '}
-        <a href="https://mistx.io" onClick={() => window.fathom.trackGoal('WDNN8XUH', 0)}>
+        <a className={'mistx-link'} href="https://mistx.io" onClick={() => window.fathom.trackGoal('WDNN8XUH', 0)}>
           mistX.io
         </a>{' '}
         to stay unsandwiched!
@@ -53,7 +53,7 @@ const PageHeader = (x: number) => {
     body = (
       <>
         You&apos;ve been sandwiched, wtf were you thinking! Next time use{' '}
-        <a href="https://mistx.io" onClick={() => window.fathom.trackGoal('WDNN8XUH', 0)}>
+        <a className={'mistx-link'} href="https://mistx.io" onClick={() => window.fathom.trackGoal('WDNN8XUH', 0)}>
           mistX.io
         </a>
       </>

--- a/src/components/common/EthAddressForm/EthAddressForm.styled.ts
+++ b/src/components/common/EthAddressForm/EthAddressForm.styled.ts
@@ -11,25 +11,26 @@ export const StyledAddressForm = styled.form`
     width: 394px;
   }
   .input-wrapper {
-    flex: 1;
-    margin-left: 20px;
+    // Sensitive Styling here for Firefox and Safari
+    width: 368px;
     height: 72px;
     display: inline;
     background: #e9e9e9;
+    border-radius: 16px;
   }
-  .rectangle {
-    display: inline;
+  span {
+    height: 100%;
     padding: 1.5px;
-    min-height: 24px;
+    margin-left: 20px;
+    margin-right: 5px;
     background-color: #c4c4c4;
   }
   input {
     height: 100%;
-    width: 100%;
+    width: 236px;
     border: 0;
     display: inline;
     background: #e9e9e9;
-    padding: 15px;
     font-size: 18px;
     color: #434343;
 
@@ -41,15 +42,16 @@ export const StyledAddressForm = styled.form`
   }
   button {
     display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 72px;
+    //justify-content: center;
+    //align-items: center;
+    width: 89px; // Sensitive Styling here for Firefox and Safari
     height: 72px;
     background-color: rgba(var(--color-primary));
     border: none;
-    float: right;
     border-top-right-radius: 16px;
     border-bottom-right-radius: 16px;
+    svg {
+    }
   }
   &.small {
     .input-wrapper {
@@ -57,6 +59,7 @@ export const StyledAddressForm = styled.form`
     }
     button {
       height: 60px;
+      width: 69px;
     }
   }
 `

--- a/src/components/common/EthAddressForm/EthAddressForm.styled.ts
+++ b/src/components/common/EthAddressForm/EthAddressForm.styled.ts
@@ -42,20 +42,19 @@ export const StyledAddressForm = styled.form`
   }
   button {
     display: flex;
-    //justify-content: center;
-    //align-items: center;
     width: 89px; // Sensitive Styling here for Firefox and Safari
     height: 72px;
     background-color: rgba(var(--color-primary));
     border: none;
     border-top-right-radius: 16px;
     border-bottom-right-radius: 16px;
-    svg {
-    }
   }
   &.small {
     .input-wrapper {
       height: 60px;
+    }
+    input {
+      width: 290px;
     }
     button {
       height: 60px;

--- a/src/components/common/EthAddressForm/EthAddressForm.styled.ts
+++ b/src/components/common/EthAddressForm/EthAddressForm.styled.ts
@@ -18,7 +18,7 @@ export const StyledAddressForm = styled.form`
     background: #e9e9e9;
     border-radius: 16px;
   }
-  span {
+  .rectangle {
     height: 100%;
     padding: 1.5px;
     margin-left: 20px;

--- a/src/components/common/EthAddressForm/EthAddressForm.tsx
+++ b/src/components/common/EthAddressForm/EthAddressForm.tsx
@@ -21,8 +21,9 @@ const EthAddressForm = ({ inputPlaceholder = 'Enter wallet address or ENS', ...p
 
   return (
     <StyledAddressForm onSubmit={() => manualAddressSubmit()} {...props}>
+      {/*<span style={{ width: 100, backgroundColor: 'red' }} />*/}
       <div className={'input-wrapper'}>
-        <div className="rectangle" />
+        <span />
         <input
           type="text"
           value={inputVal}

--- a/src/components/common/EthAddressForm/EthAddressForm.tsx
+++ b/src/components/common/EthAddressForm/EthAddressForm.tsx
@@ -22,7 +22,7 @@ const EthAddressForm = ({ inputPlaceholder = 'Enter wallet address or ENS', ...p
   return (
     <StyledAddressForm onSubmit={() => manualAddressSubmit()} {...props}>
       <div className={'input-wrapper'}>
-        <span />
+        <span className={'rectangle'} />
         {/*<div className="rectangle" />*/}
         <input
           type="text"


### PR DESCRIPTION
## Changes

- fixes EthAddressForm to work with the gray bar decoration on firefox and safari
- adds new mistX.io link styling for results page

## Screenshots

## Checklist

- [x] Lots of Sandwiches: http://localhost:3001/0xb1adceddb2941033a090dd166a462fe1c2029484
- [x] No Sandwiches: http://localhost:3001/0xd3230876c670971797a1f55a7bc100bec25759f1
- [x] Connect/Disconnect from header wallet button
- [x] Click Logo in header bar to go back to home page

Fixes #85 
